### PR TITLE
win32_ver out of range tuple reference fix

### DIFF
--- a/src/system_information_plugin/system_information.py
+++ b/src/system_information_plugin/system_information.py
@@ -31,7 +31,7 @@ def get_system_information() -> str:
     # Get Windows version (works on Windows only)
     if platform.system() == "Windows":
         win_ver = platform.win32_ver()
-        win_version = f"{win_ver[0]} {win_ver[1]} {win_ver[4]}"
+        win_version = f"{win_ver[0]} {win_ver[1]} {win_ver[3]}"
     else:
         win_version = None
 


### PR DESCRIPTION
See win32_ver() in python platform docs for reference: https://docs.python.org/3/library/platform.html

See https://github.com/hdkiller/Auto-GPT-SystemInfo/issues/1 for additional context

