### PR TITLE
the environment should already be loaded

### DIFF
--- a/src/system_information_plugin/__init__.py
+++ b/src/system_information_plugin/__init__.py
@@ -1,18 +1,12 @@
 """This is a system information plugin for Auto-GPT."""
 import os
-from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, TypedDict, TypeVar
 
 from auto_gpt_plugin_template import AutoGPTPluginTemplate
-from dotenv import load_dotenv
 
 from .system_information import get_shell_name, get_system_information
 
 PromptGenerator = TypeVar("PromptGenerator")
-
-with open(str(Path(os.getcwd()) / ".env"), "r", encoding="utf-8") as fp:
-    load_dotenv(stream=fp)
-
 
 class Message(TypedDict):
     role: str


### PR DESCRIPTION
the environment variables should already be bootstrapped  by auto-gpts own runtime.

 Using the file directly in the plugin breaks it for all environments where the environment variables might actually come from the environment (for example: with it being loaded here the plugin won't run in docker unless you bring your .env file into the container (bad practice))